### PR TITLE
Add DM key support and expand chat indexes

### DIFF
--- a/kkchat.php
+++ b/kkchat.php
@@ -139,6 +139,15 @@ function kkchat_sanitize_room_slug(string $s): string {
   return substr($s, 0, 64);
 }
 
+function kkchat_dm_key(int $a, int $b): string {
+  if ($a > $b) {
+    $tmp = $a;
+    $a   = $b;
+    $b   = $tmp;
+  }
+  return $a . ':' . $b;
+}
+
 /* ------------------------------
  * Auth/session helpers
  * ------------------------------ */


### PR DESCRIPTION
## Summary
- normalize DM lookups around a shared `dm_key` helper so long-polling, fetch, and moderation wakeups use indexed `dm_key` scans
- add the `dm_key` column on messages and expand supporting indexes/migrations for messages, reads, and users to reduce query load

## Testing
- php -l kkchat.php
- php -l inc/rest.php
- php -l inc/schema.php

------
https://chatgpt.com/codex/tasks/task_e_68dd29d14c248331b21e7b88b112f04f