### PR TITLE
Optimize active user touch session binding

### DIFF
--- a/inc/auth.php
+++ b/inc/auth.php
@@ -43,6 +43,7 @@ function kkchat_touch_active_user(): int {
     "INSERT INTO {$t['users']} (name, name_lc, gender, last_seen, ip, wp_username)
      VALUES (%s, %s, %s, %d, %s, %s)
      ON DUPLICATE KEY UPDATE
+       id = LAST_INSERT_ID(id),
        gender = VALUES(gender),
        last_seen = VALUES(last_seen),
        ip = VALUES(ip),
@@ -51,10 +52,7 @@ function kkchat_touch_active_user(): int {
   ));
 
   // Read the id and bind it to the session
-  $id = (int) $wpdb->get_var($wpdb->prepare(
-    "SELECT id FROM {$t['users']} WHERE name_lc=%s LIMIT 1",
-    $name_lc
-  ));
+  $id = (int) $wpdb->insert_id;
   if ($id > 0) $_SESSION['kkchat_user_id'] = $id;
 
   return $id;


### PR DESCRIPTION
## Summary
- ensure kkchat_touch_active_user() propagates the user id through LAST_INSERT_ID
- reuse $wpdb->insert_id to store the active user id in the session without an extra SELECT

## Testing
- php -l inc/auth.php
- not run: login + /sync + /fetch regression (WordPress environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd5afb724c8331be41b08e8edad362