### PR TITLE
Throttle sync presence cleanup

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -426,41 +426,48 @@ register_rest_route($ns, '/sync', [
     $now = time();
 
     /* ------------ presence (active users) ------------ */
-    // Cleanup (presence purge can be heavy; keep it but feel free to make it probabilistic if needed)
-    $wpdb->query($wpdb->prepare(
-      "DELETE FROM {$t['users']}
-        WHERE %d - last_seen > %d",
-      $now, kkchat_user_ttl()
-    ));
-    $wpdb->query($wpdb->prepare(
-      "UPDATE {$t['users']}
-          SET watch_flag = 0, watch_flag_at = NULL
-        WHERE watch_flag = 1
-          AND watch_flag_at IS NOT NULL
-          AND %d - watch_flag_at > %d",
-      $now, kkchat_watch_reset_after()
-    ));
-    $wpdb->query($wpdb->prepare(
-      "UPDATE {$t['users']}
-          SET typing_text=NULL, typing_room=NULL, typing_to=NULL, typing_at=NULL
-        WHERE typing_at IS NOT NULL AND %d - typing_at > 10",
-      $now
-    ));
+    $run_presence_cleanup = kkchat_sync_cleanup_should_run($now);
+    if ($run_presence_cleanup) {
+      // Cleanup (presence purge can be heavy; rate limited via kkchat_sync_cleanup_should_run)
+      $wpdb->query($wpdb->prepare(
+        "DELETE FROM {$t['users']}"
+          WHERE %d - last_seen > %d",
+        $now, kkchat_user_ttl()
+      ));
+      $wpdb->query($wpdb->prepare(
+        "UPDATE {$t['users']}"
+            SET watch_flag = 0, watch_flag_at = NULL
+          WHERE watch_flag = 1
+            AND watch_flag_at IS NOT NULL
+            AND %d - watch_flag_at > %d",
+        $now, kkchat_watch_reset_after()
+      ));
+      $wpdb->query($wpdb->prepare(
+        "UPDATE {$t['users']}"
+            SET typing_text=NULL, typing_room=NULL, typing_to=NULL, typing_at=NULL
+          WHERE typing_at IS NOT NULL AND %d - typing_at > 10",
+        $now
+      ));
+    }
 
     $admin_names = kkchat_admin_usernames();
+    $active_window = max(30, (int)apply_filters('kkchat_presence_active_sec', 120));
+    $presence_limit = max(50, (int)apply_filters('kkchat_presence_limit', 200));
     $presence_rows = $wpdb->get_results(
       $wpdb->prepare(
-        "SELECT id,name,gender,typing_text,typing_room,typing_to,typing_at,watch_flag,wp_username,last_seen
+        "SELECT id,name,gender,typing_text,typing_room,typing_to,typing_at,watch_flag,watch_flag_at,wp_username,last_seen"
            FROM {$t['users']}
           WHERE %d - last_seen <= %d
           ORDER BY name_lc ASC
           LIMIT %d",
         $now,
-        max(30, (int)apply_filters('kkchat_presence_active_sec', 120)),
-        max(50, (int)apply_filters('kkchat_presence_limit', 200))
+        $active_window,
+        $presence_limit
       ),
       ARRAY_A
     ) ?: [];
+
+    $presence_rows = kkchat_filter_presence_rows_by_ttl($presence_rows, $now, $active_window);
 
     // 10s window for typing to be considered "active"
     $presence = array_map(function($r) use ($now, $admin_names) {
@@ -478,7 +485,7 @@ register_rest_route($ns, '/sync', [
         'name'     => (string)$r['name'],
         'gender'   => (string)$r['gender'],
         'typing'   => $typing,
-        'flagged'  => !empty($r['watch_flag']) ? 1 : 0,
+        'flagged'  => kkchat_presence_flagged_status($r, $now),
         'is_admin' => (!empty($r['wp_username']) && in_array(strtolower($r['wp_username']), $admin_names, true)) ? 1 : 0,
       ];
     }, $presence_rows);

--- a/tests/SyncCleanupTest.php
+++ b/tests/SyncCleanupTest.php
@@ -1,0 +1,100 @@
+<?php
+$tests = [];
+
+require __DIR__ . '/bootstrap.php';
+
+$tests['cleanup_runs_initially'] = function () {
+    $store = 0;
+    $ran = kkchat_sync_cleanup_should_run(
+        100,
+        5,
+        function () use (&$store) {
+            return $store;
+        },
+        function (int $ts) use (&$store): void {
+            $store = $ts;
+        }
+    );
+
+    kkchat_test_assert_true($ran, 'Cleanup should run on first invocation');
+    kkchat_test_assert_same(100, $store, 'Cleanup timestamp should update');
+};
+
+$tests['cleanup_throttles_within_interval'] = function () {
+    $store = 100;
+    $ran = kkchat_sync_cleanup_should_run(
+        103,
+        5,
+        function () use (&$store) {
+            return $store;
+        },
+        function (int $ts) use (&$store): void {
+            $store = $ts;
+        }
+    );
+
+    kkchat_test_assert_true(!$ran, 'Cleanup should be skipped within interval');
+    kkchat_test_assert_same(100, $store, 'Timestamp should remain unchanged when throttled');
+};
+
+$tests['cleanup_resumes_after_interval'] = function () {
+    $store = 100;
+    $ran = kkchat_sync_cleanup_should_run(
+        108,
+        5,
+        function () use (&$store) {
+            return $store;
+        },
+        function (int $ts) use (&$store): void {
+            $store = $ts;
+        }
+    );
+
+    kkchat_test_assert_true($ran, 'Cleanup should resume after interval passes');
+    kkchat_test_assert_same(108, $store, 'Timestamp should update after resumed cleanup');
+};
+
+$tests['cleanup_runs_when_interval_disabled'] = function () {
+    $store = 42;
+    $ran = kkchat_sync_cleanup_should_run(
+        200,
+        0,
+        function () use (&$store) {
+            return $store;
+        },
+        function (int $ts) use (&$store): void {
+            $store = $ts;
+        }
+    );
+
+    kkchat_test_assert_true($ran, 'Cleanup should run when interval is disabled');
+    kkchat_test_assert_same(42, $store, 'Timestamp should not change when interval disabled and setter skipped');
+};
+
+$tests['presence_rows_respect_ttl_filter'] = function () {
+    $rows = [
+        ['id' => 1, 'last_seen' => 190, 'watch_flag' => 0],
+        ['id' => 2, 'last_seen' => 120, 'watch_flag' => 0],
+    ];
+    $now = 200;
+    $filtered = kkchat_filter_presence_rows_by_ttl($rows, $now, 30);
+
+    kkchat_test_assert_same(1, count($filtered), 'Only one row should remain after TTL filtering');
+    kkchat_test_assert_same(1, $filtered[0]['id'], 'Old presence row should be filtered out');
+};
+
+$tests['presence_flagged_resets_after_ttl'] = function () {
+    $row = ['watch_flag' => 1, 'watch_flag_at' => 50];
+    $now = 120;
+
+    kkchat_test_assert_same(0, kkchat_presence_flagged_status($row, $now), 'Watch flag should reset after TTL');
+};
+
+$tests['presence_flagged_stays_when_recent'] = function () {
+    $row = ['watch_flag' => 1, 'watch_flag_at' => time()];
+    $now = $row['watch_flag_at'] + 10;
+
+    kkchat_test_assert_same(1, kkchat_presence_flagged_status($row, $now), 'Recent watch flag should stay active');
+};
+
+return $tests;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,74 @@
+<?php
+// Basic bootstrap for running lightweight unit tests without WordPress.
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+
+// Simple in-memory option store used by helper stubs.
+$GLOBALS['kkchat_test_options'] = [];
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value) {
+        return $value;
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $args = 1) {
+        // no-op for tests
+    }
+}
+
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path($file) {
+        return rtrim(dirname($file), '/') . '/';
+    }
+}
+
+if (!function_exists('plugin_dir_url')) {
+    function plugin_dir_url($file) {
+        return 'http://example.com/';
+    }
+}
+
+if (!defined('KKCHAT_PATH')) {
+    define('KKCHAT_PATH', __DIR__ . '/../');
+}
+
+if (!defined('KKCHAT_URL')) {
+    define('KKCHAT_URL', 'http://example.com/kkchat/');
+}
+
+if (!function_exists('wp_register_style')) {
+    function wp_register_style($handle, $src, $deps = [], $ver = null) {
+        // no-op in tests
+    }
+}
+
+if (!function_exists('get_option')) {
+    function get_option($name, $default = false) {
+        return $GLOBALS['kkchat_test_options'][$name] ?? $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($name, $value, $autoload = null) {
+        $GLOBALS['kkchat_test_options'][$name] = $value;
+        return true;
+    }
+}
+
+require_once __DIR__ . '/../inc/core-helpers.php';
+
+function kkchat_test_assert_true($condition, string $message = 'Expected condition to be truthy'): void {
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+function kkchat_test_assert_same($expected, $actual, string $message = ''): void {
+    if ($expected !== $actual) {
+        $prefix = $message !== '' ? $message . ': ' : '';
+        throw new RuntimeException($prefix . 'expected ' . var_export($expected, true) . ' got ' . var_export($actual, true));
+    }
+}

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,29 @@
+<?php
+$tests = require __DIR__ . '/SyncCleanupTest.php';
+
+$total = count($tests);
+$failures = [];
+
+foreach ($tests as $name => $test) {
+    try {
+        $test();
+        echo ".";
+    } catch (Throwable $e) {
+        $failures[$name] = $e->getMessage();
+        echo "F";
+    }
+}
+
+echo PHP_EOL;
+
+echo sprintf("Ran %d tests\n", $total);
+
+if ($failures) {
+    echo sprintf("FAILED (%d failures)\n", count($failures));
+    foreach ($failures as $name => $message) {
+        echo sprintf(" - %s: %s\n", $name, $message);
+    }
+    exit(1);
+}
+
+echo "OK\n";


### PR DESCRIPTION
## Summary
- throttle the /sync presence cleanup queries behind a configurable interval
- keep presence TTLs accurate when cleanup is skipped by filtering rows and deriving watch flag status in PHP
- add lightweight PHP tests covering cleanup throttling and TTL handling

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68dd83e64a808331b33b5cea0e1d4d98