### PR TITLE
Store raw message content

### DIFF
--- a/inc/rest.php
+++ b/inc/rest.php
@@ -1364,7 +1364,7 @@ register_rest_route($ns, '/fetch', [
         $content = esc_url_raw($image_url);
         $raw     = 'image:' . $content;
       } else {
-        $content = kkchat_html_esc($txt);
+        $content = $txt;
         $raw     = trim($txt);
       }
 

--- a/inc/schema.php
+++ b/inc/schema.php
@@ -361,7 +361,7 @@ function kkchat_run_scheduled_banners(){
       error_log("[KKchat] Banner #{$r['id']} rooms not found: {$r['rooms_csv']}");
     } else {
       // Insert one banner message per valid room
-      $content = kkchat_html_esc((string)$r['content']);
+      $content = (string)$r['content'];
       foreach ($rooms as $slug) {
         $attempts++;
         $ok = $wpdb->insert($t['messages'], [


### PR DESCRIPTION
## Summary
- store raw chat message text in the REST message insertion path, relying on client-side escaping when rendering
- persist banner content without pre-escaping so scheduled messages retain original characters

## Testing
- php -l inc/rest.php
- php -l inc/schema.php

------
https://chatgpt.com/codex/tasks/task_e_68de84e566ec8331b57bd556efb11ca8