### PR TITLE
Add gender icons to chat bubbles

### DIFF
--- a/assets/css/kkchat.css
+++ b/assets/css/kkchat.css
@@ -568,6 +568,31 @@ html, body { margin: 0; height: 100%; }
   white-space: pre-wrap;
   font-size: 16px;
 }
+#kkchat-root .bubble-meta {
+  min-width: 52px;
+  text-align: left;
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+}
+#kkchat-root .bubble-gender {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+}
+#kkchat-root .bubble-gender-icon {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+#kkchat-root .bubble-meta-text {
+  display: inline-block;
+  line-height: 1.3;
+}
 #kkchat-root .me { justify-content: flex-end; }
 #kkchat-root .me .bubble { background: var(--accent); color: #fff; border-bottom-right-radius: 4px; }
 #kkchat-root .them .bubble { background: #fff; border-bottom-left-radius: 4px; }

--- a/assets/genders/couple.svg
+++ b/assets/genders/couple.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <circle cx="5.25" cy="8" r="3.5" stroke="#ec4899" stroke-width="1.3" opacity="0.9"/>
+  <circle cx="10.75" cy="8" r="3.5" stroke="#3b82f6" stroke-width="1.3" opacity="0.9"/>
+  <path d="M6.2 11.6c.9 1 2 1.9 2.8 2.6.8-.7 1.9-1.6 2.8-2.6" stroke="#f97316" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/genders/man.svg
+++ b/assets/genders/man.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <circle cx="6.5" cy="9.5" r="3.75" stroke="#2563eb" stroke-width="1.4"/>
+  <path d="M8.8 7.2 13.8 2.2" stroke="#2563eb" stroke-width="1.4" stroke-linecap="round"/>
+  <path d="M13.8 2.2h-3.1" stroke="#2563eb" stroke-width="1.4" stroke-linecap="round"/>
+  <path d="M13.8 2.2v3.1" stroke="#2563eb" stroke-width="1.4" stroke-linecap="round"/>
+</svg>

--- a/assets/genders/nonbinary.svg
+++ b/assets/genders/nonbinary.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <path d="M8 2.2 12.3 4 14.1 8 12.3 12 8 13.8 3.7 12 1.9 8 3.7 4Z" stroke="#facc15" stroke-width="1.4" stroke-linejoin="round" fill="rgba(250,204,21,0.15)"/>
+  <circle cx="8" cy="8" r="2.4" stroke="#9333ea" stroke-width="1.2"/>
+</svg>

--- a/assets/genders/trans-ftm.svg
+++ b/assets/genders/trans-ftm.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <circle cx="7.6" cy="8.4" r="3.6" stroke="#0ea5e9" stroke-width="1.4"/>
+  <path d="M9.5 6.5 13.6 2.4" stroke="#0ea5e9" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M13.6 2.4h-2.8" stroke="#0ea5e9" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M13.6 2.4v2.8" stroke="#0ea5e9" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M5.6 10.3 2.4 13.5" stroke="#0ea5e9" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M2.4 13.5h2.9" stroke="#0ea5e9" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M2.4 13.5v-2.9" stroke="#0ea5e9" stroke-width="1.3" stroke-linecap="round"/>
+</svg>

--- a/assets/genders/trans-mtf.svg
+++ b/assets/genders/trans-mtf.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <circle cx="7.5" cy="8.5" r="3.6" stroke="#8b5cf6" stroke-width="1.4"/>
+  <path d="M9.4 6.6 13.4 2.6" stroke="#8b5cf6" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M13.4 2.6h-2.7" stroke="#8b5cf6" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M13.4 2.6v2.7" stroke="#8b5cf6" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M7.5 12v2.8" stroke="#8b5cf6" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M5.6 13.4h3.8" stroke="#8b5cf6" stroke-width="1.3" stroke-linecap="round"/>
+</svg>

--- a/assets/genders/unknown.svg
+++ b/assets/genders/unknown.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <circle cx="8" cy="8" r="6.2" stroke="#9ca3af" stroke-width="1.4" fill="rgba(148,163,184,0.12)"/>
+  <path d="M6.2 6.4c.1-1.2 1.1-2.1 2.3-2.1 1.2 0 2.1.8 2.1 1.9 0 1.2-.9 1.7-1.6 2.3-.5.4-.7.8-.7 1.4" stroke="#4b5563" stroke-width="1.3" stroke-linecap="round" fill="none"/>
+  <circle cx="8.1" cy="11.8" r="0.65" fill="#4b5563"/>
+</svg>

--- a/assets/genders/woman.svg
+++ b/assets/genders/woman.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <circle cx="8" cy="5.75" r="3.75" stroke="#d53f8c" stroke-width="1.4"/>
+  <path d="M8 9.8v5" stroke="#d53f8c" stroke-width="1.4" stroke-linecap="round"/>
+  <path d="M5.9 12.1h4.2" stroke="#d53f8c" stroke-width="1.4" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- cache user genders locally and expose helpers for rendering gender-specific icons in chat bubbles
- prepend gender icon markup to message metadata in both initial and incremental render paths and seed cache from presence payloads
- style the metadata row for icon/text layout and add SVG assets for each supported gender option

## Testing
- php -l inc/shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68df0830bb9083318f5f21110ac3feaa