### PR TITLE
Reduce long polling when tab hidden

### DIFF
--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -2690,8 +2690,8 @@ async function pollRoom(){
     params.set('limit', isCold ? String(FIRST_LOAD_LIMIT) : '250');
     
     const visible = document.visibilityState === 'visible';
-    const doLongPoll = !isCold;                // long-poll even when hidden
-    const lpTimeout = isCold ? 0 : (visible ? 25 : 35); // shorter when hidden
+    const doLongPoll = visible && !isCold;     // pause long-poll when tab hidden
+    const lpTimeout = isCold ? 0 : (doLongPoll ? (visible ? 25 : 35) : 8);
     params.set('lp', doLongPoll ? '1' : '0');
     params.set('timeout', String(lpTimeout));
 
@@ -2745,8 +2745,8 @@ async function pollDM(){
     params.set('limit', isCold ? String(FIRST_LOAD_LIMIT) : '250');
     
     const visible = document.visibilityState === 'visible';
-    const doLongPoll = !isCold;                // long-poll even when hidden
-    const lpTimeout = isCold ? 0 : (visible ? 25 : 35); // 
+    const doLongPoll = visible && !isCold;     // pause long-poll when tab hidden
+    const lpTimeout = isCold ? 0 : (doLongPoll ? (visible ? 25 : 35) : 8);
     params.set('lp', doLongPoll ? '1' : '0');
     params.set('timeout', String(lpTimeout));
 


### PR DESCRIPTION
## Summary
- disable long polling requests when the chat tab is hidden to avoid idle connections
- fall back to short timed fetches while hidden so updates still arrive

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4238eb98883318e55a799ea4c4b07