### PR TITLE
Reduce chat stream warm-up delay after tab switches

### DIFF
--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -2577,8 +2577,9 @@ if (cacheHit) {
 }
   // (No else branch — fetch happens immediately below)
 
-  await pollActive();
+  const syncPromise = pollActive().catch(()=>{});
   openStream();
+  await syncPromise;
 });
 
 document.addEventListener('click', e => {
@@ -2694,8 +2695,9 @@ roomsListEl?.addEventListener('click', async (e) => {
           markVisible(pubList);
         }
 
-        await pollActive();
+        const syncPromise = pollActive().catch(()=>{});
         openStream();
+        await syncPromise;
       }
     }
 
@@ -2924,8 +2926,9 @@ if (cacheHit) {
 }
 
 
-  await pollActive();
+  const syncPromise = pollActive().catch(()=>{});
   openStream();
+  await syncPromise;
 
 
 
@@ -3956,8 +3959,9 @@ async function init(){
     if (OPEN_DM_USER) {
       await openDM(OPEN_DM_USER);     // <-- await to avoid racing
     } else {
-      await pollActive();              // single, awaited warm-up poll
+      const syncPromise = pollActive().catch(()=>{});              // single, awaited warm-up poll
       openStream();
+      await syncPromise;
     }
   } catch (e) {
     // optionally log e


### PR DESCRIPTION
## Summary
- open the SSE stream immediately when switching between rooms or DMs instead of waiting for the sync request to finish
- apply the same non-blocking warm-up when a room is left and on the initial load so new messages arrive without delay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e44a4324988331ae0042dd22e10d18