### PR TITLE
Ensure DM opens fetch history without cache

### DIFF
--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -2150,10 +2150,10 @@ if (currentDM === id){
     muteFor(1200);
   stopStream();
   currentDM = null;
-  applyCache(activeCacheKey());
+  const cacheHit = applyCache(activeCacheKey());
   setComposerAccess();
   showView('vPublic');
-  pollActive().catch(()=>{});
+  pollActive(!cacheHit).catch(()=>{});
   openStream();
 }
     renderDMSidebar();
@@ -2577,7 +2577,7 @@ if (cacheHit) {
 }
   // (No else branch — fetch happens immediately below)
 
-  const syncPromise = pollActive().catch(()=>{});
+  const syncPromise = pollActive(!cacheHit).catch(()=>{});
   openStream();
   await syncPromise;
 });
@@ -2926,7 +2926,7 @@ if (cacheHit) {
 }
 
 
-  const syncPromise = pollActive().catch(()=>{});
+  const syncPromise = pollActive(!cacheHit).catch(()=>{});
   openStream();
   await syncPromise;
 


### PR DESCRIPTION
## Summary
- ensure DM and room openings trigger a cold /sync poll whenever no cached transcript exists
- reuse the cache-hit flag when closing a DM so the next view refresh fetches the right history

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e46ac71dc8833183c93017721ec6b6