### PR TITLE
Add admin tools dropdown and logout option to settings menu

### DIFF
--- a/assets/css/kkchat.css
+++ b/assets/css/kkchat.css
@@ -292,11 +292,13 @@ html, body { margin: 0; height: 100%; }
   font-size: 1.5rem;
   padding-right: 5px;
 }
-#kkchat-root .tab-settings {
+#kkchat-root .tab-settings { 
   position: relative;
   display: flex;
   align-items: center;
 }
+#kkchat-root .tab-settings + .tab-settings { margin-left: 6px; }
+#kkchat-root .tab-settings.tab-settings-admin .tabicons { padding-left: 5px; }
 #kkchat-root .tab-settings.is-open > .tabicons {
   color: var(--brand);
 }
@@ -338,6 +340,9 @@ html, body { margin: 0; height: 100%; }
   font-size: .95rem;
   cursor: pointer;
   transition: border-color .15s ease, background-color .15s ease;
+  display: block;
+  color: inherit;
+  text-decoration: none;
 }
 #kkchat-root .tab-settings-item:hover,
 #kkchat-root .tab-settings-item:focus {


### PR DESCRIPTION
## Summary
- add an admin-only tools dropdown next to the tab settings gear with quick links to moderation pages
- extend the settings menu with a logout button and ensure menus close appropriately
- tweak styling so dropdown items style anchors consistently

## Testing
- php -l inc/shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68e5b518e6f083318711e9d2512bdc2c