### PR TITLE
Open admin tool links in new tabs

### DIFF
--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -2853,7 +2853,7 @@ function renderRoomTabs(){
         ${ADMIN_LINKS.map(link => {
           const safeText = esc(link.text || '');
           const safeUrl  = escAttr(link.url || '#');
-          return `<a class="tab-settings-item" href="${safeUrl}" role="menuitem">${safeText}</a>`;
+          return `<a class="tab-settings-item" href="${safeUrl}" role="menuitem" target="_blank" rel="noopener noreferrer">${safeText}</a>`;
         }).join('')}
       </div>
     </div>`;


### PR DESCRIPTION
## Summary
- update admin tools menu links to open in a new browser tab
- add noopener and noreferrer rel attributes for security

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5b6f82e4483319343ec70e4ecaca3