### PR TITLE
Reorder left sidebar buttons in chat UI

### DIFF
--- a/inc/shortcode/templates/app.php
+++ b/inc/shortcode/templates/app.php
@@ -24,9 +24,6 @@
   <button type="button" data-view="users" aria-selected="true">
     <span class="material-symbols-rounded" aria-hidden="true">person</span> <span class="badge" id="kk-countUsers">0</span>
   </button>
-  <button type="button" data-view="rooms" aria-selected="false">
-    <span class="material-symbols-rounded" aria-hidden="true">chat</span> <span class="badge" id="kk-countRooms">0</span>
-  </button>
   <button type="button" data-view="dms" aria-selected="false">
     <span class="material-symbols-rounded" aria-hidden="true">mail</span> <span class="badge" id="kk-countDMs">0</span>
   </button>
@@ -35,6 +32,9 @@
     <span class="material-symbols-rounded" aria-hidden="true">flag</span> <span class="badge" id="kk-countReports">0</span>
   </button>
   <?php endif; ?>
+  <button type="button" data-view="rooms" aria-selected="false">
+    <span class="material-symbols-rounded" aria-hidden="true">chat</span> <span class="badge" id="kk-countRooms">0</span>
+  </button>
 </div>
 
             <div class="leftview" id="kk-lvUsers" active>


### PR DESCRIPTION
### Motivation
- Change the left sidebar tab order so the buttons appear as: Users → DM → Reports (admin only) → Rooms to match the requested UI order.

### Description
- Moved the `rooms` button in `inc/shortcode/templates/app.php` to render after the admin-only `reports` button, preserving existing `data-view` attributes and the admin-only conditional.

### Testing
- Ran `php -l inc/shortcode/templates/app.php` which reported no syntax errors.
- Attempted a Playwright screenshot of the running app, but it failed with `ERR_EMPTY_RESPONSE` because there was no local web server available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaed6b518483318438843eefd629c6)