### PR TITLE
Redesign login layout with brand panel and logo slot

### DIFF
--- a/assets/css/kkchat.css
+++ b/assets/css/kkchat.css
@@ -1953,6 +1953,9 @@ html, body { margin: 0; height: 100%; }
   border-radius: calc(var(--radius-lg) + 4px);
   box-shadow: 0 32px 68px rgba(5, 7, 12, 0.6);
   backdrop-filter: var(--frost);
+  max-height: 100%;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 #kkchat-root .kk-login-shell {
   display: grid;
@@ -2392,8 +2395,14 @@ body.kkchat-no-scroll { overflow: hidden; }
 #kkchat-root .kk-agree input { width: auto; min-width: 30px; }
 
 @media (max-width: 900px) {
+  #kkchat-root .kk-wrap {
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: calc(32px + env(safe-area-inset-bottom, 0px));
+  }
   #kkchat-root .login {
     padding: 16px;
+    margin-bottom: env(safe-area-inset-bottom, 0px);
   }
   #kkchat-root .kk-login-shell {
     grid-template-columns: 1fr;

--- a/assets/css/kkchat.css
+++ b/assets/css/kkchat.css
@@ -1970,11 +1970,12 @@ html, body { margin: 0; height: 100%; }
   padding: clamp(18px, 4vw, 28px);
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  gap: 8px;
   min-height: 370px;
 }
 #kkchat-root .kk-login-logo-slot {
-  margin-bottom: 28px;
+  margin-bottom: 12px;
   min-height: 88px;
   display: flex;
   align-items: center;

--- a/assets/css/kkchat.css
+++ b/assets/css/kkchat.css
@@ -1945,25 +1945,79 @@ html, body { margin: 0; height: 100%; }
 }
 
 #kkchat-root .login {
-  max-width: 600px;
-  margin: 0px auto;
-  padding: 32px;
-  background: linear-gradient(160deg, rgba(15, 18, 28, 0.92) 0%, rgba(8, 10, 17, 0.95) 100%);
-  border: 1px solid rgba(122, 136, 196, 0.28);
-  border-radius: var(--radius-lg);
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 22px;
+  background: linear-gradient(145deg, rgba(16, 19, 30, 0.9) 0%, rgba(9, 11, 17, 0.96) 100%);
+  border: 1px solid rgba(122, 136, 196, 0.24);
+  border-radius: calc(var(--radius-lg) + 4px);
   box-shadow: 0 32px 68px rgba(5, 7, 12, 0.6);
   backdrop-filter: var(--frost);
 }
-
-#kkchat-root .login h1 {
-  margin-top: 0;
-  margin-bottom: 0px;
-  font-size: 3rem;
-  line-height: 3rem;
-  font-family: 'Bebas Neue', system-ui, sans-serif;
-  color: var(--brand);
+#kkchat-root .kk-login-shell {
+  display: grid;
+  grid-template-columns: minmax(240px, 1.1fr) minmax(360px, 1fr);
+  gap: 18px;
+  align-items: stretch;
 }
-
+#kkchat-root .kk-login-branding {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(122, 136, 196, 0.22);
+  background: linear-gradient(140deg, rgba(20, 23, 36, 0.92) 0%, rgba(11, 13, 21, 0.93) 100%);
+  padding: clamp(18px, 4vw, 28px);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  min-height: 370px;
+}
+#kkchat-root .kk-login-logo-slot {
+  margin-bottom: 28px;
+  min-height: 88px;
+  display: flex;
+  align-items: center;
+}
+#kkchat-root .kk-login-logo-img {
+  max-width: min(300px, 100%);
+  max-height: 88px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+}
+#kkchat-root .kk-login-logo-fallback {
+  font-family: 'Bebas Neue', system-ui, sans-serif;
+  font-size: clamp(3.2rem, 10vw, 4.8rem);
+  line-height: 1;
+  color: #fff;
+  letter-spacing: .04em;
+}
+#kkchat-root .kk-login-branding h1 {
+  margin: 0 0 8px;
+  font-size: clamp(2.3rem, 6vw, 3.3rem);
+  line-height: .95;
+  font-family: 'Bebas Neue', system-ui, sans-serif;
+  color: #fff;
+}
+#kkchat-root .kk-login-branding p {
+  margin: 0;
+  color: rgba(228, 231, 241, 0.84);
+  font-size: 1rem;
+}
+#kkchat-root .kk-login-form-card {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(122, 136, 196, 0.22);
+  background: linear-gradient(160deg, rgba(15, 18, 28, 0.92) 0%, rgba(8, 10, 17, 0.95) 100%);
+  padding: clamp(20px, 3.5vw, 30px);
+}
+#kkchat-root .kk-login-form-card h2 {
+  margin: 0 0 6px;
+  font-size: clamp(1.45rem, 4vw, 2rem);
+  color: #fff;
+}
+#kkchat-root .kk-login-lead {
+  margin-top: 0;
+  margin-bottom: 12px;
+  color: rgba(228, 231, 241, 0.84);
+}
 #kkchat-root .login label { display: block; font-weight: 700; margin: 10px 0 6px; }
 #kkchat-root .login input,
 #kkchat-root .login select {
@@ -2336,6 +2390,22 @@ body.kkchat-no-scroll { overflow: hidden; }
 }
 #kkchat-root .kk-agree { display: flex !important; align-items: center; gap: 8px; font-weight: 600; }
 #kkchat-root .kk-agree input { width: auto; min-width: 30px; }
+
+@media (max-width: 900px) {
+  #kkchat-root .login {
+    padding: 16px;
+  }
+  #kkchat-root .kk-login-shell {
+    grid-template-columns: 1fr;
+  }
+  #kkchat-root .kk-login-branding {
+    min-height: 0;
+  }
+  #kkchat-root .kk-login-logo-slot {
+    margin-bottom: 14px;
+    min-height: 56px;
+  }
+}
 
 #kkchat-root {
   --kk-font-scale: 1;

--- a/inc/shortcode/templates/login.php
+++ b/inc/shortcode/templates/login.php
@@ -1,11 +1,35 @@
 <?php if (!defined('ABSPATH')) exit; ?>
-    <div class="login">
+<?php
+$custom_logo_url = '';
+if (function_exists('has_custom_logo') && has_custom_logo()) {
+  $logo_id = (int) get_theme_mod('custom_logo');
+  if ($logo_id > 0) {
+    $custom_logo_url = wp_get_attachment_image_url($logo_id, 'full') ?: '';
+  }
+}
+?>
+<div class="login">
   <div class="kk-login-overlay" aria-hidden="true" style="display:none">
     <div class="kk-login-spinner" role="status" aria-label="Laddar"></div>
   </div>
+
+  <div class="kk-login-shell">
+    <aside class="kk-login-branding" aria-label="Varumärke">
+      <div class="kk-login-logo-slot">
+        <?php if (!empty($custom_logo_url)): ?>
+          <img src="<?= esc_url($custom_logo_url) ?>" alt="KKompis logotyp" class="kk-login-logo-img">
+        <?php else: ?>
+          <span class="kk-login-logo-fallback" aria-hidden="true">KK</span>
+        <?php endif; ?>
+      </div>
+      <h1>Välkommen till KKchatten</h1>
+      <p>Snabb, enkel och trygg inloggning. Välj uppgifter nedan för att komma in i chatten.</p>
+    </aside>
+
+    <section class="kk-login-form-card" aria-label="Inloggning">
       <?php if ($wp_logged): ?>
-        <h1>Välkommen till KKchatten</h1>
-        <p>Du är inloggad som <b><?= kkchat_html_esc($wp_username) ?></b>. Kön hämtas inte automatiskt. Vänligen fyll i ditt kön.</p>
+        <h2>Fortsätt som <?= kkchat_html_esc($wp_username) ?></h2>
+        <p class="kk-login-lead">Du är inloggad i WordPress. Välj kön för att slutföra inloggningen till chatten.</p>
         <form id="kk-loginForm" method="post">
           <input type="hidden" name="csrf_token" value="<?= kkchat_html_esc($session_csrf) ?>">
           <input type="hidden" name="via_wp" value="1">
@@ -15,8 +39,8 @@
             <option>Man</option><option>Woman</option><option>Couple</option>
             <option>Trans (MTF)</option><option>Trans (FTM)</option><option>Non-binary/other</option>
           </select>
-                    <p class="kk-terms">
-            <a href="<?= esc_url( home_url('/anvandarvillkor-kkchatt/') ) ?>" target="_blank" rel="noopener">Klicka här för att läsa våra användarvillkor</a>.
+          <p class="kk-terms">
+            <a href="<?= esc_url(home_url('/anvandarvillkor-kkchatt/')) ?>" target="_blank" rel="noopener">Klicka här för att läsa våra användarvillkor</a>.
           </p>
           <label class="kk-agree">
             <input type="checkbox" id="login_agree" name="login_agree" required>
@@ -27,8 +51,8 @@
           <div id="kk-loginErr" class="err" style="display:none"></div>
         </form>
       <?php else: ?>
-        <h1>Välj ett smeknamn</h1>
-        <p>Du kommer att visas som <b>namn-guest</b>. Namnet blir ledigt igen när du loggar ut eller blir inaktiv.</p>
+        <h2>Välj ett smeknamn</h2>
+        <p class="kk-login-lead">Du visas som <b>namn-guest</b>. Namnet blir ledigt när du loggar ut eller blir inaktiv.</p>
         <form id="kk-loginForm" method="post">
           <input type="hidden" name="csrf_token" value="<?= kkchat_html_esc($session_csrf) ?>">
           <label for="login_nick">Smeknamn</label>
@@ -39,8 +63,9 @@
             <option>Man</option><option>Woman</option><option>Couple</option>
             <option>Trans (MTF)</option><option>Trans (FTM)</option><option>Non-binary/other</option>
           </select>
-                    <p class="kk-terms">
-            <a href="<?= esc_url( home_url('/anvandarvillkor-kkchatt/') ) ?>" target="_blank" rel="noopener">Klicka här för att läsa våra användarvillkor</a>.          </p>
+          <p class="kk-terms">
+            <a href="<?= esc_url(home_url('/anvandarvillkor-kkchatt/')) ?>" target="_blank" rel="noopener">Klicka här för att läsa våra användarvillkor</a>.
+          </p>
           <label class="kk-agree">
             <input type="checkbox" id="login_agree" name="login_agree" required>
             Jag är 18+ och godkänner användarvillkoren
@@ -50,7 +75,9 @@
           <div id="kk-loginErr" class="err" style="display:none"></div>
         </form>
       <?php endif; ?>
-    </div>
+    </section>
+  </div>
+</div>
     <script>
     (function(){
       const API = "<?= $ns ?>";


### PR DESCRIPTION
### Motivation
- Make the login page visually match the rest of the site and provide a clear place for the site logo so branding is consistent.

### Description
- Reworked the login template (`inc/shortcode/templates/login.php`) into a two-column `kk-login-shell` with a left branding panel and a right form card, preserving existing fields and JS behavior.
- Added code to read the active WordPress custom logo (`custom_logo`) and render it in a dedicated logo slot with a `KK` fallback when no logo is set (`$custom_logo_url`, `kk-login-logo-slot`).
- Updated styles in `assets/css/kkchat.css` to support the new grid layout, branding card, logo sizing/fallback typography, refreshed form-card styling, and responsive stacking for mobile.
- Kept the original loading overlay, terms checkbox, and submit handling intact so login behavior remains unchanged.

### Testing
- Ran `php -l inc/shortcode/templates/login.php` and it reported no syntax errors (success).
- Basic local validation commands (`git status --short`) were used to confirm files changed (informational only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c923b0d2a083319c011fc1885cb247)